### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use PhpFp\Writer\Writer;
 $halve = function ($number) {
     $log = new Monoid(['Halving the number']);
 
-    return Writer::tell('Halving the number')->map(
+    return Writer::tell($log)->map(
         function () use ($number)
         {
             return $number / 2;


### PR DESCRIPTION
Fixed the example so it will run (replace the string with the $log monoid, which I think is what is intended)